### PR TITLE
Update Huawei services SDK version to the latest

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,6 +43,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.huawei.hms:hwid:4.0.0.300"
+    implementation "com.huawei.hms:hwid:6.4.0.301"
     implementation "com.google.android.gms:play-services-base:17.3.0"
 }


### PR DESCRIPTION
Google, since the last month, detected non-compliant code in this plugin. The problem was with the outdated Huawei services SDK. I have updated the SDK version and tested if it is compatible with the package's code, and everything is working fine, so I'm opening this PR to solve that non-compliant code problem. 