### PR TITLE
Fix Duplicate class kotlin.internal.jdk7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.chimou.flutter_hms_gms_availability'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.8.10'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
Fix Duplicate class kotlin.internal.jdk7

Issue:
`A failure occurred while executing com.android.build.gradle.internal.tasks.CheckDuplicatesRunnable > Duplicate class kotlin.collections.jdk8.CollectionsJDK8Kt found in modules jetified-kotlin-stdlib-1.8.10`